### PR TITLE
a map!

### DIFF
--- a/map.html
+++ b/map.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>East Boston Eviction Map</title>
+  <meta charset="utf-8" />
+
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
+  <style>
+.leaflet-container {
+  height: 98vh;
+  width: device-width;
+}
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <!-- for production -->
+  <script src="https://cdn.rawgit.com/AntiEvictionBoston/utility/04919ce0385ec9296b6dc4fccad64718b9751564/east_boston.js"></script>
+  <!-- for testing (updates more quickly, but will be throttled on the real site) -->
+  <!-- <script src="https://rawgit.com/AntiEvictionBoston/utility/master/east_boston.js"></script> -->
+</body>
+</html>


### PR DESCRIPTION
I added a map.

This sources the compiled JS from the [leaflet](https://github.com/AntiEvictionBoston/LeafletMap) repo.

It's a little wacky (using rawgit) - basically if you want to use the CDN (for production) you need to go to [rawgit](https://rawgit.com) and add the newest version of the file, and then update `map.html` to source the JS from the right url. The file url you supply to rawgit should look something like:

https://raw.githubusercontent.com/AntiEvictionBoston/utility/04919ce0385ec9296b6dc4fccad64718b9751564/east_boston.js

(i.e. you're looking at a particular version of the file, on a particular commit). We need to do this because rawgit caches _one version_ of a file for the CDN - it doesn't watch the repo to pick up changes. So basically, when we're ready to show the map to the public we commit a final version of the JS, get a rawgit url for the file in that commit, and add that to the page.

If you're developing and want to see changes reflected more quickly you can use the more generic link that just proxies to `raw.githubusercontent`, which looks like:

https://rawgit.com/AntiEvictionBoston/utility/master/east_boston.js

we don't want to use this in production though, because rawgit throttles this if there is excessive traffic. It's kinda slow too.
