### PR TITLE
handle text overflow on the menu title

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -110,12 +110,21 @@ h2 {
   a {
     color: #ffffff;
   }
-  
+
   .navbar-brand {
     font-size: 1em;
     color: #ffffff;
     text-transform: uppercase;
     text-shadow: none;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+}
+
+@media screen and (max-width: $screen-xs) {
+  .navbar-brand {
+    width: 80%;
   }
 }
 


### PR DESCRIPTION
just a few quick styling changes, from this:

![bigger-menu](https://cloud.githubusercontent.com/assets/6207644/13755629/808baddc-e9f2-11e5-95dc-4cd8582e0f01.png)

to this:

![menu-smaller](https://cloud.githubusercontent.com/assets/6207644/13755603/6a76f006-e9f2-11e5-85c5-0128b5a26099.png)
